### PR TITLE
Process terminal bench 2.0 leaderboard results

### DIFF
--- a/scripts/process_terminal_bench.py
+++ b/scripts/process_terminal_bench.py
@@ -16,7 +16,7 @@ raw-data/terminal-bench/1.0/
     └── ...
 ```
 
-## 2.0 Format ([terminal-bench-2-leaderboard](https://huggingface.co/datasets/alexgshaw/terminal-bench-2-leaderboard))
+## 2.0 Format ([terminal-bench-2-leaderboard](https://huggingface.co/datasets/alexgshaw/terminal-bench-2-leaderboard/tree/main/submissions/terminal-bench/2.0))
 ```
 raw-data/terminal-bench/2.0/
 ├── <Agent>__<Model>/

--- a/scripts/process_terminal_bench.py
+++ b/scripts/process_terminal_bench.py
@@ -2,21 +2,28 @@
 """
 Process Terminal Bench evaluation results into standardized format.
 
-A standalone Python script [process_terminal_bench.py](process_terminal_bench.py) is provided to convert
-Terminal Bench raw evaluation data from [terminal-bench-core@0.1.1](https://github.com/laude-institute/terminal-bench-leaderboard/tree/main/results/terminal-bench-core%400.1.1) into the standardized format used by eval-arena.
+Supports both Terminal Bench 1.0 and 2.0 data formats.
 
-The function expects raw data in this directory structure:
+## 1.0 Format ([terminal-bench-core@0.1.1](https://github.com/laude-institute/terminal-bench-leaderboard/tree/main/results/terminal-bench-core%400.1.1))
 ```
-raw-data/terminal-bench-core@0.1.1/
+raw-data/terminal-bench/1.0/
 ├── YYYYMMDD_<agent-name>_<model-name>/
 │   ├── YYYY-MM-DD__HH-MM-SS__results.json  (5 files, one per run)
 │   └── ...
 └── YYYYMMDD_<agent-name>_<model-name>/
     ├── <run-name-1>/
-    │   └── results.json  (aggregated results for this run)
-    ├── <run-name-2>/
-    │   └── results.json
+    │   └── results.json  (aggregated results with 'is_resolved' field)
     └── ...
+```
+
+## 2.0 Format ([terminal-bench-2-leaderboard](https://huggingface.co/datasets/alexgshaw/terminal-bench-2-leaderboard))
+```
+raw-data/terminal-bench/2.0/
+├── <Agent>__<Model>/
+│   ├── YYYY-MM-DD__HH-MM-SS/
+│       └── result.json  (aggregated with reward_stats and exception_stats)
+│   └── ...
+└── ...
 ```
 """
 
@@ -27,13 +34,8 @@ import numpy as np
 import pandas as pd
 import os
 
-def process_terminal_bench(raw_data_dir='raw-data/terminal-bench-core@0.1.1'):
-    """
-    Convert terminal-bench-core@0.1.1 evaluation results into the standardized format used by eval-arena.
 
-    Output will be saved to 'data/terminal-bench.jsonl'
-    """
-
+def process_terminal_bench_1_0(raw_data_dir='raw-data/terminal-bench/1.0'):
     records = []
 
     for exp_dir in sorted(glob.glob(f"{raw_data_dir}/*")):
@@ -50,19 +52,16 @@ def process_terminal_bench(raw_data_dir='raw-data/terminal-bench-core@0.1.1'):
         result_files = []
 
         # Case 1: Aggregated results.json at the root of the experiment directory
-        # (e.g., orchestrator_claude-4-sonnet has only one run with single aggregated results.json)
         root_results = os.path.join(exp_dir, 'results.json')
         if os.path.exists(root_results):
             result_files.append(root_results)
 
         # Case 2: Direct results files in the experiment directory
-        # (e.g., <experiment_name>/<run_id>_results.json)
         if not result_files:
             direct_results = glob.glob(f"{exp_dir}/*_results.json")
             result_files.extend(direct_results)
 
         # Case 3: Aggregated results.json in immediate subdirectories (run directories)
-        # (e.g., <experiment_name>/<run_id>/results.json)
         if not result_files:
             for subdir in glob.glob(f"{exp_dir}/*/"):
                 results_file = os.path.join(subdir, 'results.json')
@@ -97,19 +96,96 @@ def process_terminal_bench(raw_data_dir='raw-data/terminal-bench-core@0.1.1'):
 
         # Create records for each task
         for task_id, results_list in task_results.items():
-            # Calculate pass1 as the success rate across all runs
             pass1 = np.mean(results_list)
             count = len(results_list)
 
             records.append({
-                'benchmark_id': 'terminal-bench',
+                'benchmark_id': 'terminal-bench-1.0',
                 'model': model_full_name,
                 'example_id': task_id,
                 'pass1': pass1,
                 'count': count
             })
 
-    # Create DataFrame
+    df = pd.DataFrame(records)
+
+    if len(df) == 0:
+        print("\nWarning: No records were created!")
+        return df
+
+    print(f"\nProcessed {len(df)} task results")
+    print(f"Unique models: {df['model'].nunique()}")
+    print(f"Unique tasks: {df['example_id'].nunique()}")
+
+    return df
+
+
+def process_terminal_bench_2_0(raw_data_dir='raw-data/terminal-bench/2.0'):
+    records = []
+
+    for model_dir in sorted(os.listdir(raw_data_dir)):
+        model_path = os.path.join(raw_data_dir, model_dir)
+        if not os.path.isdir(model_path) or model_dir.startswith('.'):
+            continue
+
+        print(f"Processing {model_dir}...")
+
+        # Track task results across all runs
+        task_results = defaultdict(list)  # task_name -> list of pass/fail (1.0/0.0)
+
+        # Find all run directories (date-stamped folders)
+        for run_dir in sorted(os.listdir(model_path)):
+            run_path = os.path.join(model_path, run_dir)
+            if not os.path.isdir(run_path):
+                continue
+
+            result_file = os.path.join(run_path, "result.json")
+            if not os.path.exists(result_file):
+                continue
+
+            try:
+                with open(result_file, 'r') as f:
+                    data = json.load(f)
+
+                # Extract from stats.evals
+                stats = data.get("stats", {}).get("evals", {})
+
+                for _, eval_data in stats.items():
+                    reward_stats = eval_data.get("reward_stats", {}).get("reward", {})
+                    exception_stats = eval_data.get("exception_stats", {})
+
+                    # Collect all trial IDs
+                    all_trial_ids = set().union(*reward_stats.values(), *exception_stats.values())
+
+                    # Get successful trials
+                    success_ids = set(reward_stats.get("1.0", []))
+
+                    # Mark each trial as success (1.0) or failure (0.0)
+                    for trial_id in all_trial_ids:
+                        parts = trial_id.rsplit("__", 1)
+                        if len(parts) == 2:
+                            task_name = parts[0]
+                            task_results[task_name].append(1.0 if trial_id in success_ids else 0.0)
+
+            except Exception as e:
+                print(f"  Error processing {result_file}: {e}")
+                continue
+
+        print(f"  Found {len(task_results)} tasks")
+
+        # Create records for each task
+        for task_name, results_list in task_results.items():
+            pass1 = np.mean(results_list)
+            count = len(results_list)
+
+            records.append({
+                'benchmark_id': 'terminal-bench-2.0',
+                'model': model_dir,
+                'example_id': task_name,
+                'pass1': pass1,
+                'count': count
+            })
+
     df = pd.DataFrame(records)
 
     if len(df) == 0:
@@ -124,31 +200,32 @@ def process_terminal_bench(raw_data_dir='raw-data/terminal-bench-core@0.1.1'):
 
 
 if __name__ == '__main__':
-    # Process the data
-    print("Starting Terminal Bench data processing...")
-    print("=" * 60)
+    os.makedirs('data', exist_ok=True)
 
-    df_terminal_bench = process_terminal_bench()
-
-    # Save to file
-    if len(df_terminal_bench) > 0:
-        output_file = 'data/terminal-bench.jsonl'
-
-        # Create data directory if it doesn't exist
-        os.makedirs('data', exist_ok=True)
-
-        # Select standard fields for output
-        df_output = df_terminal_bench[['benchmark_id', 'model', 'example_id', 'pass1', 'count']]
-        df_output.to_json(output_file, orient='records', lines=True)
-
-        print(f"\n{'=' * 60}")
-        print(f"Saved {len(df_output)} records to {output_file}")
+    if os.path.isdir('raw-data/terminal-bench/1.0'):
+        print("=" * 60)
+        print("Processing Terminal Bench 1.0...")
         print("=" * 60)
 
-        # Display first few records
-        print("\nFirst 10 records:")
-        print(df_output.head(10).to_string())
+        df_1_0 = process_terminal_bench_1_0()
 
-        print("\n✓ Processing complete!")
-    else:
-        print("\n✗ No data was processed. Please check your raw data directory.")
+        if len(df_1_0) > 0:
+            output_file = 'data/terminal-bench-1.0.jsonl'
+            df_1_0.to_json(output_file, orient='records', lines=True)
+            print(f"Saved {len(df_1_0)} records to {output_file}")
+
+    if os.path.isdir('raw-data/terminal-bench/2.0'):
+        print("\n" + "=" * 60)
+        print("Processing Terminal Bench 2.0...")
+        print("=" * 60)
+
+        df_2_0 = process_terminal_bench_2_0()
+
+        if len(df_2_0) > 0:
+            output_file = 'data/terminal-bench-2.0.jsonl'
+            df_2_0.to_json(output_file, orient='records', lines=True)
+            print(f"Saved {len(df_2_0)} records to {output_file}")
+
+    print("\n" + "=" * 60)
+    print("Processing complete!")
+    print("=" * 60)


### PR DESCRIPTION
- Added script to process terminal bench 2.0 leaderboard results (different format as 1.0).
   - The [hugging face repo](https://huggingface.co/datasets/alexgshaw/terminal-bench-2-leaderboard) was only set up recently so don't contain results for the entire leaderboard.
- Still using folder name as the `model_id` because it already combine agent and model name, while metadata file has separate field for each. 
- Updated 1.0 script to distinguish version in `benchmark_id`

Generated `terminal-bench-2.0.jsonl` has 623 records, 7 unique models, 89 tasks/problems.